### PR TITLE
Cannot find module 'smartfritz-promise'

### DIFF
--- a/fritz.coffee
+++ b/fritz.coffee
@@ -9,7 +9,7 @@ module.exports = (env) ->
   _ = env.require 'lodash'
 
   # Require [smartfritz library](https://github.com/andig/smartfritz)
-  fritz = env.require 'smartfritz-promise'
+  fritz = require 'smartfritz-promise'
 
 
   # ###FritzPlugin class


### PR DESCRIPTION
Suggested fix for https://github.com/andig/pimatic-fritz/issues/16
Supposedly, 'smartfritz-promise' is not available via pimatic env
