### PR TITLE
Suggested changes for pimatic 0.9 readiness

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -56,6 +56,10 @@ module.exports = {
         description: "Show the temperature input spinbox in the GUI"
         type: "boolean"
         default: true
+      guiShowValvePosition:
+        description: "Show the valve position in the GUI"
+        type: "boolean"
+        default: false
   }
   FritzTemperatureSensor: {
     title: "Comet DECT temperature sensor"

--- a/fritz.coffee
+++ b/fritz.coffee
@@ -143,16 +143,21 @@ module.exports = (env) ->
 
     # Initialize device by reading entity definition from middleware
     constructor: (@config, lastState, @plugin) ->
-      @id = config.id
-      @name = config.name
-      @interval = 1000 * (config.interval or plugin.config.interval)
+      @id = @config.id
+      @name = @config.name
+      @interval = 1000 * (@config.interval or @plugin.config.interval)
 
       # keep updating
       @requestUpdate()
-      setInterval( =>
+      @intervalTimerID = setInterval( =>
         @requestUpdate()
       , @interval
       )
+      super()
+
+    destroy: () ->
+      if @intervalTimerID?
+        clearInterval @intervalTimerID
       super()
 
     # poll device according to interval
@@ -232,18 +237,23 @@ module.exports = (env) ->
 
     # Initialize device by reading entity definition from middleware
     constructor: (@config, lastState, @plugin) ->
-      @id = config.id
-      @name = config.name
-      @interval = 1000 * (config.interval or plugin.config.interval)
+      @id = @config.id
+      @name = @config.name
+      @interval = 1000 * (@config.interval or @plugin.config.interval)
 
       # keep updating
       @requestUpdate()
-      setInterval( =>
+      @intervalTimerID = setInterval( =>
         @requestUpdate()
       , @interval
       )
       super()
 
+    destroy: () ->
+      if @intervalTimerID?
+        clearInterval @intervalTimerID
+      super()
+      
     # poll device according to interval
     requestUpdate: ->
       @plugin.fritzCall("getGuestWlan")
@@ -319,9 +329,9 @@ module.exports = (env) ->
 
     # Initialize device by reading entity definition from middleware
     constructor: (@config, lastState, @plugin) ->
-      @id = config.id
-      @name = config.name
-      @interval = 1000 * (config.interval or plugin.config.interval)
+      @id = @config.id
+      @name = @config.name
+      @interval = 1000 * (@config.interval or @plugin.config.interval)
 
       # initial state
       @_temperature = lastState?.temperature?.value
@@ -338,12 +348,17 @@ module.exports = (env) ->
 
       # keep updating
       @requestUpdate()
-      setInterval( =>
+      @intervalTimerID = setInterval( =>
         @requestUpdate()
       , @interval
       )
       super()
 
+    destroy: () ->
+      if @intervalTimerID?
+        clearInterval @intervalTimerID
+      super()
+    
     # implement env.devices.HeatingThermostat
     changeTemperatureTo: (temperatureSetpoint) ->
       @_setSynced(false)
@@ -393,21 +408,26 @@ module.exports = (env) ->
 
     # Initialize device by reading entity definition from middleware
     constructor: (@config, lastState, @plugin) ->
-      @id = config.id
-      @name = config.name
-      @interval = 1000 * (config.interval or plugin.config.interval)
+      @id = @config.id
+      @name = @config.name
+      @interval = 1000 * (@config.interval or @plugin.config.interval)
 
       # initial state
       @_temperature = lastState?.temperature?.value
 
       # keep updating
       @requestUpdate()
-      setInterval( =>
+      @intervalTimerID = setInterval( =>
         @requestUpdate()
       , @interval
       )
       super()
 
+    destroy: () ->
+      if @intervalTimerID?
+        clearInterval @intervalTimerID
+      super()
+      
     # poll device according to interval
     requestUpdate: ->
       @plugin.fritzCall("getTemperature", @config.ain)

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "url": "https://github.com/andig/pimatic-fritz"
   },
   "dependencies": {
-    "smartfritz-promise": "^0.4.1",
-    "bluebird": "^3.0.2"
+    "smartfritz-promise": "^0.4.2",
+    "bluebird": "^3.3.5"
   },
   "peerDependencies": {
     "pimatic": ">0.8.91"


### PR DESCRIPTION
Hi, ich habe einige notwendige Änderungen vorgenommen um die Lauffähigkeit der Erweiterung mit Pimatic 0.9 zu gewährleisten. Alle Änderungen sind abwärtskompatibel (der Code läuft sowohl mit der aktuellen 0.8er Release als auch mit dem 0.9er branch. Einige Anmerkungen:
- Ich habe gesehen, dass es bereits eine smartfritz-promise@0.5 gibt, allerdings funktioniert mit dieser Version bei mir die Temperaturanzeige nicht. 
- In der 0.9er Version können Devices zur Laufzeit gelöscht und geändert werden. Daher ist die destroy() Methode wichtig um Hintergrund Tasks (Timer, Callouts) abzubrechen.*\* Ich habe hierfür nur eine rudimentäre Implementierung angelegt, die den update timer löscht**. Hier ist aber noch Ergänzungbedarf: Laufende Callouts eines Device via Smartfritz sollten auch abbgebrochen werden!
- Pimatic 0.9 führt eine striktere Prüfung des Config-Schema durch. Daher müssen alle Keys, die zur Laufzeit erzeugt werden (z.B. customConfig) im Schema vereinbart werden. Falls die Keys nur transient genutzt werden sollen, musst Du Dir eine Kopie der Config für die Verwendung im Code erstellen, z.B. via lodash.cloneDeep()
- Sweetpi wird heute noch eine ausführliche Anleitung für Plugin-Entwickler veröffentlichen. Darin ist alles noch mal ausführlich beschrieben  
