### PR TITLE
FritzThermostatDevice doesn't implement changeStateTo from env.devices.HeatingThermostat

### DIFF
--- a/fritz.coffee
+++ b/fritz.coffee
@@ -409,6 +409,11 @@ module.exports = (env) ->
           @_setSynced(true)
           Promise.resolve()
 
+    # implement env.devices.HeatingThermostat
+    changeModeTo: (mode) ->
+      # changing modes is not supported.
+      return Promise.resolve()
+
     # implement env.devices.TemperatureSensor
     _setTemperature: (value) ->
       if @_temperature is value then return


### PR DESCRIPTION
The base class env.devices.HeatingThermostat in pimatic that FritzThermostatDevice extends has a function changeStateTo, which throws an error by default if used. 
I guess that the AVM thermostats don't support changing the state, but pimatic-fritz should implement this function nevertheless. This PR fixes https://github.com/michbeck100/pimatic-hap/issues/53