### PR TITLE
 Fixed error handling in case getSessionID raises a rejection with sid '0000000000000000'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ You can load the plugin by editing your `config.json` to include:
 
 ## Device Configuration
 
-Devices are linked to fritz plugin channels by specifying the `class`, `middleware` and `ain` properties:
+Devices are linked to fritz devices by the given the `class` and `ain` properties. Note, however, the `FritzWlan`
+device constitutes a special case. It has has no `ain` property as it is mapped to a function block of the 
+FritzBox router:
 
     ...
     "devices": [
@@ -63,4 +65,5 @@ Devices are linked to fritz plugin channels by specifying the `class`, `middlewa
     },
   ...
 
-A list of available fritz switch and thermostat AINs will be logged to the pimatic console when the plugin is started.
+A list of available fritz switch, thermostat, and contact sensor AINs will be logged to the pimatic 
+console when the plugin is started.

--- a/fritz.coffee
+++ b/fritz.coffee
@@ -151,8 +151,11 @@ module.exports = (env) ->
               env.logger.warn "Re-establishing session at " + @config.url
               return fritz.getSessionID(@config.user, @config.password, { url: @config.url })
                 .then (@sid) =>
-                  # @todo provide handling of sid == '0000000000000000'
                   return fritz[functionName] @sid, args..., { url: @config.url } # retry with new sid
+                .catch =>
+                  # handle sid == '0000000000000000'
+                  throw new Error "Invalid Session-Id: Invalid username or password"
+
             env.logger.error "Cannot access #{error.options?.url}: #{error.response?.statusCode}"
             throw error
 


### PR DESCRIPTION
The error case needs to be handled to map rejection '0000000000000000' from fritz.getSessionID() to an error object.

The other commit contains a suggested rewording for device configuration section. As far as I can  see the `middleware` is a left-over from the Volkszähler plugin 